### PR TITLE
Handle SIGSEGV signals caused by the C2Rust runtime

### DIFF
--- a/MVEE/Inc/MVEE_monitor.h
+++ b/MVEE/Inc/MVEE_monitor.h
@@ -714,6 +714,11 @@ private:
     bool handle_rdtsc_event                  (int index);
 #endif
 
+	//
+	// Handle C2Rust-specific signals;
+	//
+	bool handle_c2rust_event                 (int index);
+
 	// 
 	// Generic SIGTRAP handling. 
 	//

--- a/MVEE/Src/MVEE_monitor.cpp
+++ b/MVEE/Src/MVEE_monitor.cpp
@@ -1307,7 +1307,7 @@ bool monitor::handle_c2rust_event(int variantnum)
 			throw RwRegsFailure(variantnum, "C2Rust IP check");
 
 		if (!interaction::resume_until_syscall(variants[variantnum].variantpid))
-			throw RwRegsFailure(variantnum, "C2Rust resume");
+			throw ResumeFailure(variantnum, "C2Rust resume");
 
 		return true;
 	}

--- a/MVEE/Src/MVEE_monitor.cpp
+++ b/MVEE/Src/MVEE_monitor.cpp
@@ -1121,6 +1121,8 @@ void monitor::handle_event (interaction::mvee_wait_status& status)
 		{
 			if (handle_rdtsc_event(index))
 				return;
+			if (handle_c2rust_event(index))
+				return;
 		}
 #endif
 		else if (status.data == SIGSTOP)
@@ -1266,6 +1268,52 @@ bool monitor::handle_rdtsc_event(int variantnum)
     return false;
 }
 #endif
+
+/*-----------------------------------------------------------------------------
+    handle_c2rust_event - Handle SIGSEGV signals caused by C2Rust
+
+    @param variantnum variant index
+
+    @return true if the SIGSEGV signal was handled, false otherwise
+-----------------------------------------------------------------------------*/
+bool monitor::handle_c2rust_event(int variantnum)
+{
+	unsigned long eip;
+
+	// read current opcode
+	if (!interaction::fetch_ip(variants[variantnum].variantpid, eip))
+		throw RwRegsFailure(variantnum, "C2Rust IP check");
+
+	const char c2rust_marker[] = "C2RUST_INVPTR";
+	constexpr size_t marker_size = sizeof(c2rust_marker);
+	char buf[marker_size];
+	unsigned long marker_start = eip - marker_size;
+	if (!rw::read_struct(variants[variantnum].variantpid,
+						 (void*)marker_start, marker_size, &buf))
+		throw RwMemFailure(variantnum, "C2Rust marker check");
+
+	if (memcmp(c2rust_marker, buf, marker_size) == 0)
+	{
+		debugf("%s - Found C2Rust marker at %p\n",
+			   call_get_variant_pidstr(variantnum).c_str(),
+			   (void*)marker_start);
+
+		short delta;
+		if (!rw::read_primitive<short>(variants[variantnum].variantpid,
+									   (void*)(marker_start - 2), delta))
+			throw RwMemFailure(variantnum, "C2Rust marker check");
+
+		if (!interaction::write_ip(variants[variantnum].variantpid, eip + delta))
+			throw RwRegsFailure(variantnum, "C2Rust IP check");
+
+		if (!interaction::resume_until_syscall(variants[variantnum].variantpid))
+			throw RwRegsFailure(variantnum, "C2Rust resume");
+
+		return true;
+	}
+
+	return false;
+}
 
 /*-----------------------------------------------------------------------------
     handle_attach_event


### PR DESCRIPTION
This patch adds ReMon support for the C2Rust cross-checkers' "invalid pointer checks", which are small code snippets which attempt to dereference a given pointer. We need to catch SIGSEGV signals from these snippets and resume execution at the right instruction pointer.